### PR TITLE
Update MacPorts to 2.5.2

### DIFF
--- a/macports-ci
+++ b/macports-ci
@@ -9,7 +9,7 @@ export COLUMNS=80
 # 2. as source ./macports-ci
 # as of now, choice 2 only changes the env var COLUMNS.
 
-MACPORTS_VERSION=2.4.3
+MACPORTS_VERSION=2.5.2
 MACPORTS_PREFIX=/opt/local
 MACPORTS_SYNC=tarball
 


### PR DESCRIPTION
2.5.2 is released 13 days ago: https://github.com/macports/macports-base/releases/tag/v2.5.2