### PR TITLE
Run the MacPorts installer verbosely

### DIFF
--- a/macports-ci
+++ b/macports-ci
@@ -105,7 +105,7 @@ else
 # download installer:
   curl -LO $URL/$MACPORTS_PKG
 # install:
-  sudo installer -pkg $MACPORTS_PKG -target /
+  sudo installer -verbose -pkg $MACPORTS_PKG -target /
 fi
 
 # update:


### PR DESCRIPTION
Sometimes the installation runs more than 10 minutes without any output and thus the build is killed by Travis CI. Adding `-verbose` avoids such a scenario.