### PR TITLE
Add macOS 11.x (BigSur) support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,18 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * 0'
-    
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+
+# A workflow run is made up of several jobs that execute in parallel
 jobs:
   with_pkg:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - os: macos-10.15
+          - os: macos-11.0
+    runs-on: ${{ matrix.config.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Install
@@ -28,7 +34,13 @@ jobs:
         source macports-ci localports test_portfiles
         sudo port -N install xdrfile1
   with_prefix:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - os: macos-10.15
+          - os: macos-11.0
+    runs-on: ${{ matrix.config.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Install
@@ -42,7 +54,13 @@ jobs:
         source macports-ci localports test_portfiles
         sudo port -N install xdrfile1
   with_ccache:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - os: macos-10.15
+          - os: macos-11.0
+    runs-on: ${{ matrix.config.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
   - osx_image: xcode10.3
   - osx_image: xcode11.6
   - osx_image: xcode12
+  - osx_image: xcode12.3
+  - osx_image: xcode12.5
 # test all images installing in $HOME/opt
   - osx_image: xcode7.3
     env: PRE=$HOME/opt
@@ -26,6 +28,10 @@ matrix:
     env: PRE=$HOME/opt
   - osx_image: xcode12
 #    env: PRE=$HOME/opt
+  - osx_image: xcode12.3
+    env: PRE=$HOME/opt
+  - osx_image: xcode12.5
+    env: PRE=$HOME/opt
 # test latest image with a different sync mode
   - osx_image: xcode9.4
     env: OPT=--sync=rsync

--- a/macports-ci
+++ b/macports-ci
@@ -107,6 +107,11 @@ elif test "$OSX_VERSION" == 10.14 ; then
   OSX_NAME=Mojave
 elif test "$OSX_VERSION" == 10.15 ; then
   OSX_NAME=Catalina
+# BigSur versions match 11.* regexp
+elif test "$(echo $OSX_VERSION | cut -c1-2)" == 11 ; then
+  # MacPorts BigSur installer filename is MacPorts-${MACPORTS_VERSION}-11-BigSur.pkg
+  OSX_VERSION=11
+  OSX_NAME=BigSur
 else
   echo "macports-ci: Unknown OSX version $OSX_VERSION"
   exit 1


### PR DESCRIPTION
This adds support for using `macports-ci` on macOS 11.x BigSur.

For the record, I use a patched version of the script since a couple of weeks on GitHub Actions 
which offered macOS 11 VMs and it works as expected (see the `Install MacPorts` log of 
[that job](https://github.com/anlambert/talipot/runs/3106475900?check_suite_focus=true) for instance).