### PR TITLE
Refresh shell cache after homebrew removal

### DIFF
--- a/macports-ci
+++ b/macports-ci
@@ -72,6 +72,7 @@ if test "$KEEP_BREW" = no ; then
   chmod +x uninstall
   ./uninstall --force
   popd
+  hash -r  # So that /usr/bin/curl can be found below
 else
   echo "macports-ci: keeping HomeBrew"
 fi


### PR DESCRIPTION
At least macOS 11 bash needs a `hash -r` after removing Homebrew curl, otherwise it can't find /usr/bin/curl.